### PR TITLE
fixed memory leaks for -clar -cln -ln -lar

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -118,3 +118,22 @@ Added a separate help file relieve main.c of its clutter. Added the ability to r
 specific functions. Updated README.md and documentation.
 
 *Type `lst -version` to view your version of **Liszt***
+
+## **@version 1.0.21** ##
+September 14, 2020
+
+Plugging memory leaks
+
+-added "wordfree(&mainDir);" to line 394 of note.c in clearNotes()
+-added "wordfree(&archiveDir);" to line 426 of note.c in clearArchiveNotes()
+The above lines free the words even if there's an early return in the case of no notes
+
+-added "free(--temp);" to line 86 of helper.c in getCurrentNotePath()
+This is necessary since "cJSON_PrintUnformatted()" returns a malloced char array
+
+-added "closedir(directory);" on line 194 of helper.c in printDirectory()
+That way in the case of an early return, the directory is still freed, which didn't
+occur before
+
+by Bwoltz
+

--- a/src/helper.c
+++ b/src/helper.c
@@ -82,6 +82,7 @@ void getCurrentNotePath(char* currentNotePath) {
 	temp++;
 	temp[strlen(temp) - 1] = '\0';
 	strcpy(currentNotePath, temp);
+	free(--temp);
 	cJSON_Delete(data);
 }
 
@@ -189,6 +190,7 @@ void printDirectory(char* dirName, char* shortName) {
 		if (strcmp(shortName, " ") == 0) counter--; // decrement counter bc don't want to include default in the count
 		if (!counter) {
 			printf("You have no%snotes at the moment.\n", shortName);
+			closedir(directory);
 			return;
 		}
 		printf("\033[1mFound %d%snotes\033[0m\n", counter, shortName);

--- a/src/note.c
+++ b/src/note.c
@@ -391,6 +391,7 @@ void clearNotes() {
 		readDirectory(mainDir.we_wordv[0], notes, &numNotes);
 		if (numNotes == 1) {
 			printf("You have no notes to clear!\n");
+			wordfree(&mainDir);
 			return;
 		}
 
@@ -422,6 +423,7 @@ void clearArchiveNotes() {
 		readDirectory(archiveDir.we_wordv[0], archives, &numNotes);
 		if (!numNotes) {
 			printf("You have no notes to clear!\n");
+			wordfree(&archiveDir);
 			return;
 		}
 


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
Plugging memory leaks for Issue "Lots of memory leaks #50"

## 📄 Motivation and Context
Memory fixes

## 🧪 How Has This Been Tested?
Tested using:
valgrind --leak-check=full -v ./lst -clar
valgrind --leak-check=full -v ./lst -cln
valgrind --leak-check=full -v ./lst -lar
valgrind --leak-check=full -v ./lst -ln

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

note.c:

-added "wordfree(&mainDir);" to line 394 in clearNotes()
-added "wordfree(&archiveDir);" to line 426 in clearArchiveNotes()
The above lines free the words even if there's an early return in the case of no notes

helper.c:

-added "free(--temp);" to line 86 in getCurrentNotePath()
This is necessary since "cJSON_PrintUnformatted()" returns a malloced char array
-added "closedir(directory);" on line 194 in printDirectory()
That way in the case of an early return, the directory is still freed, which didn't occur before

