### PR TITLE
Handle empty string for getCurrentNotePath result

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -48,34 +48,44 @@ char *getCurrentNote(char **current_note_path) {
 	*current_note_path = getCurrentNotePath();
 	char slash = '/';
 	char *current_note_name = malloc(MAX_LENGTH * sizeof(char));
-	strcpy(current_note_name, strrchr(*current_note_path, '/') + 1);
+	if (*current_note_path != NULL && *current_note_path[0] != '\0') {
+		strcpy(current_note_name, strrchr(*current_note_path, '/') + 1);
+	}
 	return current_note_name;
 }	
 
 
 char *getCurrentNotePath() {
+	char *current_note_path = calloc(1, sizeof(char));
 	char *data_file = getDataFile();
 
 	FILE *to_read;
 	to_read = fopen(data_file, "r");
-	//char dataStream[MAX_LENGTH];
 
-	//fgets(line, sizeof(line), toRead);
-	//strcpy(dataStream, line);
-	char line[MAX_LENGTH];
-	char *current_note_path = strdup(fgets(line, MAX_LENGTH * sizeof(char), to_read));
-	/*
-	while (fgets(line, MAX_LENGTH * sizeof(char), toRead)) {
-		strcat(dataStream, line);
-	}	
-	fclose(toRead);
+	if (to_read) {
+		//char dataStream[MAX_LENGTH];
 
-	cJSON *data = cJSON_Parse(dataStream);
-	cJSON *currentNote = cJSON_GetObjectItem(data, "current_note");
-	char *current_note_path = cJSON_PrintUnformatted(currentNote);
-	*/
-	current_note_path[strlen(current_note_path)] = '\0'; // to get rid of the newline
-	//cJSON_Delete(data);
+		//fgets(line, sizeof(line), toRead);
+		//strcpy(dataStream, line);
+		char line[MAX_LENGTH];
+		char *res = fgets(line, MAX_LENGTH * sizeof(char), to_read);
+		if (res != NULL) {
+			free(current_note_path);
+			current_note_path = strdup(res);
+			/*
+			while (fgets(line, MAX_LENGTH * sizeof(char), toRead)) {
+				strcat(dataStream, line);
+			}
+			fclose(toRead);
+
+			cJSON *data = cJSON_Parse(dataStream);
+			cJSON *currentNote = cJSON_GetObjectItem(data, "current_note");
+			char *current_note_path = cJSON_PrintUnformatted(currentNote);
+			*/
+			current_note_path[strlen(current_note_path)] = '\0'; // to get rid of the newline
+			//cJSON_Delete(data);
+		}
+	}
 	free(data_file);
 	fclose(to_read);
 	return current_note_path;


### PR DESCRIPTION
## 🚀 Description

This changes getCurrentNotePath() to handle an empty `data_file` or a `data_file` that doesn't exist.  This use case should only be possible when a user has upgraded their install from an older version that previously used `data_file.json`

## 📄 Motivation and Context

This change makes upgrading from older versions easier for the end user and relates to #52 (the work left on #52 would be pushing an updated version to the liszt brew tap)

## 🧪 How Has This Been Tested?

Testing this change locally on my Mac running Big Sur.  Compiled following the instructions in the README (`cmake . && make`)

I blew away the `~/.liszt` folder, installed `lst` via brew, ran the brew installed `lst` to create the problematic file structure, then ran the `lst` with these changes and I didn't experience the crash.

I also manually removed `data_file` and tested my change against an empty `data_file`

## 📦 Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [x] My code follows the code style of this project(Do your best to follow code styles. If none apply just skip this).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
