### PR TITLE
Fix warnings

### DIFF
--- a/src/install.c
+++ b/src/install.c
@@ -57,13 +57,13 @@ int makeFiles() {
 	return 0;
 }
 
-void str_append(char* destination_str, char* str, char* appendant)
+void str_append(char* destination_str, const char* str, const char* appendant)
 {
     strcpy(destination_str, str);
     strcat(destination_str, appendant);
 }
 
-int makeDir(char* tilde, char* dirname) {
+int makeDir(char* tilde, const char* dirname) {
 	struct stat st = {0};
 	char path[MAX_LENGTH];
 	str_append(path, tilde, dirname);
@@ -81,7 +81,7 @@ int makeDirectories() {
 	const char* dirnames[] = {"/.liszt", "/.liszt/background", "/.liszt/main", "/.liszt/archive"};
 	
 	for (int i = 0; i <= 3; i++) {
-		char* dirname = dirnames[i];
+		const char* dirname = dirnames[i];
 		int result = makeDir(tilde, dirname);
 		if (result == -1) return -1;
 	};

--- a/src/install.h
+++ b/src/install.h
@@ -20,7 +20,7 @@ int makeFiles();
 /*
  * Function which helps to reuse code in makeFiles() function
  */
-void str_append(char* destination_str, char* str, char* appendant);
+void str_append(char* destination_str, const char* str, const char* appendant);
 
 /*
  * Helper that makes an individual directory and returns -1 if it fails to do so

--- a/src/memory.c
+++ b/src/memory.c
@@ -17,7 +17,7 @@ void appendMemory(char* memory, char* note) {
 void loopHelper(char temp[MAX_LENGTH], char line[MAX_LENGTH], FILE* source, long row, FILE* target, int doPrint) {
 	int counter = 0;
 
-	while (fgets(line, sizeof(line), source)) {
+	while (fgets(line, MAX_LENGTH, source)) {
 		if (counter + 1 == row) {
 			strcpy(temp, line);
 			counter++;


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description

Fix a few compiler warnings, on of the warnings indicates buggy behavior.

## 📄 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
When building my compiler (gcc 12.2.0 at the time I write this) complained about two issues, which I addressed to make liszt build without warnings:

- add several `const` in install.c and install.h where appropriate - this should not break anything since the pointers in question are only used as source for string copies.
- set the maximum length in a `strncpy` to the size of the array instead of using the `sizeof` operator, which would just give you the size of a pointer to an element in the array (in my case, on an i7, 8 instead of 256), and that is just wrong and should probably have resulted in an error instead of a warning.

<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?

The build now finishes without warnings, and while I have not tested the resulting code I didn't change any logic. The character pointers I made `const` are really immutable, and the fix of a bug with the size of the array is clearly an improvement that should prevent a segmentation fault, if nothing else.

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project(Do your best to follow code styles. If none apply just skip this).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
